### PR TITLE
fix(typescript): allow objects while creating actions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare module 'reduxsauce' {
   import { Action, AnyAction, Reducer } from 'redux';
 
   export interface Actions {
-    [action: string]: string[] | null;
+    [action: string]: (string[] | DefaultActionTypes) | null;
   }
 
   export interface DefaultActionTypes {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,12 @@
 declare module 'reduxsauce' {
-  import { Action, AnyAction, Reducer } from 'redux';
+  import { Action, AnyAction, Reducer, ActionCreator } from 'redux';
 
   export interface Actions {
-    [action: string]: (string[] | DefaultActionTypes) | null;
+    [action: string]: (string[] | DefaultActionTypes | ActionCreator<DefaultActionTypes>) | null;
   }
 
   export interface DefaultActionTypes {
-    [action: string]: string;
+    [action: string]: string | number | DefaultActionTypes | null;
   }
 
   export interface DefaultActionCreators {


### PR DESCRIPTION
When creating actions, you can pass in an object literal (DefaultActionTypes).  However, the typescript definition incorrectly didn't allow this.  This PR addresses that.

This bug was found by @vinipachecov and reported here: https://github.com/jkeam/reduxsauce/issues/92
And by @sayjeyhi and reported here: https://github.com/jkeam/reduxsauce/issues/89