### PR TITLE
Handle numbers in action/type names

### DIFF
--- a/lib/createActions.js
+++ b/lib/createActions.js
@@ -7,7 +7,7 @@ const defaultOptions = {
 
 // matches each word in a camelCaseString (except the first)
 // consecutive capitals are treated as one word
-const RX_CAPS = /(?!^)([A-Z][a-z]+|[A-Z]+(?=[A-Z]|\b))/g
+const RX_CAPS = /(?!^)([A-Z][a-z0-9]+|[A-Z][A-Z0-9]*(?=[A-Z]|\b))/g
 
 // converts a camelCaseWord into a SCREAMING_SNAKE_CASE word
 const camelToScreamingSnake = pipe(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reduxsauce",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reduxsauce",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Some aesthetic toppings for your Redux meal.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reduxsauce",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Some aesthetic toppings for your Redux meal.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build",
     "ci:publish": "yarn semantic-release",
     "semantic-release": "semantic-release",
-    "install": "npm run build"
+    "prepare": "npm run build"
   },
   "keywords": [
     "redux"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint": "standard",
     "prepublishOnly": "npm run build",
     "ci:publish": "yarn semantic-release",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "install": "npm run build"
   },
   "keywords": [
     "redux"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "lint": "standard",
     "prepublishOnly": "npm run build",
     "ci:publish": "yarn semantic-release",
-    "semantic-release": "semantic-release",
-    "prepare": "npm run build"
+    "semantic-release": "semantic-release"
   },
   "keywords": [
     "redux"

--- a/test/createActionsTest.js
+++ b/test/createActionsTest.js
@@ -18,6 +18,20 @@ test('types are snake case', t => {
   t.is(Types.HELLO_WORLD, 'HELLO_WORLD')
 })
 
+test('type names handle consecutive capitals', t => {
+  const { Types } = createActions({ setVIPById: null })
+  t.is(Types.SET_VIP_BY_ID, 'SET_VIP_BY_ID')
+})
+
+test('type names handle numbers', t => {
+  const { Types } = createActions({
+    storeS3Key: null,
+    usePython3Instead: null,
+  })
+  t.is(Types.STORE_S3_KEY, 'STORE_S3_KEY')
+  t.is(Types.USE_PYTHON3_INSTEAD, 'USE_PYTHON3_INSTEAD')
+})
+
 test('null produces a type-only action creator', t => {
   const { Creators } = createActions({ helloWorld: null })
   t.is(typeof Creators.helloWorld, 'function')


### PR DESCRIPTION
A recent update to reduxsauce's making of type names broke our code because it changed the way it was handling numbers in the type name.

We have an action, `storeS3Key`, which we were expecting to be translated to `STORE_S3_KEY`. However, with the change to the regex that converts to SCREAMING_SNAKE_CASE, it was being translated to `STORES3_KEY`. This PR changes that to treat numbers as being part of the preceding word.