### PR TITLE
feat(action): Allow creating an action without any overrides

### DIFF
--- a/lib/createActions.js
+++ b/lib/createActions.js
@@ -51,7 +51,7 @@ const createActionCreator = (name, extraPropNames, options) => {
   // "properties" is defined as an object of {prop name: default value}
   if (is(Object, extraPropNames)) {
     const defaultProps = extraPropNames
-    return (valueObject) => {
+    return (valueObject = {}) => {
       const providedProps = pick(Object.keys(defaultProps), valueObject)
       return { type, ...defaultProps, ...providedProps }
     }

--- a/test/createActionsTest.js
+++ b/test/createActionsTest.js
@@ -48,6 +48,12 @@ test('{"foo": 1, "bar": 2} produces a valid action creator', t => {
   t.deepEqual(Creators.helloWorld({ foo: 10, foobar: 3 }), { type: 'HELLO_WORLD', foo: 10, bar: 2 })
 })
 
+test('{"foo": 1, "bar": 2} produces a valid action creator and can call action without overrides', t => {
+  const { Creators } = createActions({ helloWorld: { foo: 1, bar: 2 } })
+  t.is(typeof Creators.helloWorld, 'function')
+  t.deepEqual(Creators.helloWorld(), { type: 'HELLO_WORLD', foo: 1, bar: 2 })
+})
+
 test('custom action creators are supported', t => {
   const { Creators } = createActions({ custom: () => 123 })
   t.is(Creators.custom(), 123)


### PR DESCRIPTION
Inspired by @snmishra.  Allow creating an action without specifying overrides to the parameters passed in during `createActions`.